### PR TITLE
Update main.py

### DIFF
--- a/main.py
+++ b/main.py
@@ -33,7 +33,7 @@ async def image_download(session, img_url, img_path, semaphore):
     async with semaphore:
         img = await session.get(img_url)
         content = await img.read()
-        # 如果下载图片的路径不存在再下载，防止重复下载文件
+        # 如果下载图片不存在，再下载，防止重复下载文件
         if not os.path.exists(img_path):
             with open(img_path, 'wb') as f:
                 f.write(content)  # save img
@@ -64,7 +64,7 @@ def download_images(url_dict, folder_path, user_agent):
         opener = urllib.request.build_opener()
         opener.addheaders = [('User-agent', user_agent)]
         urllib.request.install_opener(opener)
-        save_name = folder_path + "\\" + name
+        save_name = os.path.join(folder_path,name)
         try:
             urllib.request.urlretrieve(url, save_name)
         except Exception as e:
@@ -90,7 +90,6 @@ def write_file(folder_path, file_name, file_data):
 
 
 def write_image_url_json(out_folder_path,all_img_dict):
-    # print(all_img_dict)
     all_img_dict_json = json.dumps(all_img_dict,sort_keys=False, indent=4, separators=(',', ': '))
     write_file(out_folder_path, 'all_img_dict.json', all_img_dict_json)
     return 0
@@ -99,7 +98,6 @@ def write_image_url_json(out_folder_path,all_img_dict):
 def read_image_url_json(out_folder_path):
     with open(os.path.join(out_folder_path,'all_img_dict.json'), 'r', encoding='utf-8') as f:
         all_img_dict = json.load(f)
-    # print(all_img_dict)
     return all_img_dict
 
 def create_url2local_dict(regex, file_data, file_name):
@@ -229,12 +227,12 @@ class MdImageLocal:
 
 
 def recursion(cur_path):
-    a = os.listdir(cur_path)
-    for filename in a:
+    filenames = os.listdir(cur_path)
+    for filename in filenames:
         print("\n")
-        p = os.path.join(cur_path, filename)
-        if os.path.isdir(p):
-            recursion(p)
+        folder_path = os.path.join(cur_path, filename)
+        if os.path.isdir(folder_path):
+            recursion(folder_path)
         elif filename.strip() == 'out':
             continue
     MdImageLocal(md_path=cur_path, log=args.log, modify_source=args.modify_source).run()

--- a/main.py
+++ b/main.py
@@ -16,8 +16,9 @@ import random
 import re
 import string
 import time
-
+import json
 import aiohttp
+import urllib.request
 
 
 def create_folder(folder="out"):
@@ -32,21 +33,43 @@ async def image_download(session, img_url, img_path, semaphore):
     async with semaphore:
         img = await session.get(img_url)
         content = await img.read()
-        with open(img_path, 'wb') as f:
-            f.write(content)  # save img
+        # 如果下载图片的路径不存在再下载，防止重复下载文件
+        if not os.path.exists(img_path):
+            with open(img_path, 'wb') as f:
+                f.write(content)  # save img
+            time.sleep(0.1)
+        else:
+            logging.info(f"Skipped file: {img_path}\n")
+            print(f"Skipped file: {img_path}")
 
 
 async def download(url_dict, out_folder_path):
     """
     Download images in url_dict, use async to speed up.
     """
-    semaphore = asyncio.Semaphore(8)  # limit max coroutine numbers to 8
+    semaphore = asyncio.Semaphore(2)  # limit max coroutine numbers to 2
     # Create session which contains a connection pool
     async with aiohttp.ClientSession() as session:
         # Create all tasks
         await asyncio.gather(*[image_download(session, img_url, os.path.join(out_folder_path, img_path), semaphore)
                                for img_url, img_path in url_dict.items()])
 
+
+def download_images(url_dict, folder_path, user_agent):
+    """
+    Download the images from the links obtained from the markdown files to the "destination folder"
+    The user-agent can be specified in order to circumvent some simple potential connection block
+    """
+    for url, name in url_dict.items():
+        opener = urllib.request.build_opener()
+        opener.addheaders = [('User-agent', user_agent)]
+        urllib.request.install_opener(opener)
+        save_name = folder_path + "\\" + name
+        try:
+            urllib.request.urlretrieve(url, save_name)
+        except Exception as e:
+            logging.exception(f"Error when downloading {url}")
+        # time.sleep(random.randint(0, 2))
 
 def open_and_read(file_path):
     """
@@ -65,6 +88,19 @@ def write_file(folder_path, file_name, file_data):
     with open(os.path.join(folder_path, file_name), "w", encoding="utf-8") as file:
         file.write(file_data)
 
+
+def write_image_url_json(out_folder_path,all_img_dict):
+    # print(all_img_dict)
+    all_img_dict_json = json.dumps(all_img_dict,sort_keys=False, indent=4, separators=(',', ': '))
+    write_file(out_folder_path, 'all_img_dict.json', all_img_dict_json)
+    return 0
+
+
+def read_image_url_json(out_folder_path):
+    with open(os.path.join(out_folder_path,'all_img_dict.json'), 'r', encoding='utf-8') as f:
+        all_img_dict = json.load(f)
+    # print(all_img_dict)
+    return all_img_dict
 
 def create_url2local_dict(regex, file_data, file_name):
     """
@@ -136,42 +172,60 @@ class MdImageLocal:
                             level=logging.DEBUG if log else logging.ERROR)
         logging.info(f"New folder created: {self.out_folder_path}\n")
         print(f"New folder created: {self.out_folder_path}")
+        
 
     def run(self):
         all_img_dict = {}  # dict that collect all images' urls and paths
-        # Loop throught every markdown file on this script folder
-        for filename in os.listdir(self.md_path):
-            print("\n")
-            if filename[-3:] != ".md":
-                logging.info(f"Skipped file: {filename}\n")
-                print(f"Skipped file: {filename}")
-                continue
-            # Open and read each file
-            file_data = open_and_read(os.path.join(self.md_path, filename))
-            # Create a dictionary of images URLs for each file
-            url_dict = create_url2local_dict(self.regex, file_data, filename)
-            # skip if no online link in this file
-            if url_dict:
-                # Create a folder with md filename which contains images
-                create_folder(os.path.join(self.out_folder_path, filename[:-3] + ".assets"))
-                # Specify img folder
-                url_dict = {key: os.path.join(filename[:-3] + ".assets", value) for key, value in url_dict.items()}
-                # Edit the read content of each file, replacing the found imgs urls with local file names instead
-                edited_file_data = file_replace_url(file_data, url_dict, filename)
-                # Add url_dict to all_img_dict
-                all_img_dict.update(url_dict)
-                # Write the modified markdown files
-                write_file(self.out_folder_path, filename, edited_file_data)
-            else:
-                logging.info(f"No url! Skipped file: {filename}\n")
-                print(f"No url! Skipped file: {filename}")
-            print(f"Closed file: {filename}")
-            logging.info(f"Closed file: {filename}\n")
+        # 判断是否是 .assets 文件夹，如果是的话，则 all_img_dict 置为空
+        # 如果不存在 all_img_dict.json 就说明在该文件夹是第一次运行，则读取所有文件并创建 all_img_dict.json
+        if self.out_folder_path[-7:]==".assets":
+            all_img_dict={}
+        elif not os.path.exists(os.path.join(self.out_folder_path,'all_img_dict.json')):
+            # Loop throught every markdown file on this script folder
+            for filename in os.listdir(self.md_path):
+                print("\n")
+                if filename[-3:] != ".md":
+                    logging.info(f"Skipped file: {filename}\n")
+                    print(f"Skipped file: {filename}")
+                    continue
+                # Open and read each file
+                file_data = open_and_read(os.path.join(self.md_path, filename))
+                # Create a dictionary of images URLs for each file
+                url_dict = create_url2local_dict(self.regex, file_data, filename)
+                # skip if no online link in this file
+                if url_dict:
+                    # Create a folder with md filename which contains images
+                    create_folder(os.path.join(self.out_folder_path, filename[:-3] + ".assets"))
+                    # Specify img folder
+                    url_dict = {key: os.path.join(filename[:-3] + ".assets", value) for key, value in url_dict.items()}
+                    # Edit the read content of each file, replacing the found imgs urls with local file names instead
+                    edited_file_data = file_replace_url(file_data, url_dict, filename)
+                    # Add url_dict to all_img_dict
+                    all_img_dict.update(url_dict)
+                    # Write the modified markdown files
+                    write_file(self.out_folder_path, filename, edited_file_data)
+                else:
+                    logging.info(f"No url! Skipped file: {filename}\n")
+                    print(f"No url! Skipped file: {filename}")
+                print(f"Closed file: {filename}")
+                logging.info(f"Closed file: {filename}\n")
+            write_image_url_json(self.out_folder_path, all_img_dict)
+        # 如果存在 all_img_dict.json 则直接使用其中的内容，也就是重复运行的情况下，仍能保证所有下载的文件名均相同，不会重复下载
+        else:
+            print("all_img_dict.json exists, will use the existed url dict.")
+            all_img_dict = read_image_url_json(self.out_folder_path)
         # Download the images listed on the dictionary of found urls for each file
         loop = asyncio.get_event_loop()
         loop.run_until_complete(download(all_img_dict, self.out_folder_path))
         print("\n\n\nfiles and the downloaded images on the folder:")
         print(f"{self.out_folder_path}")
+        # 使用 noasync 的方式下载之前下载失败的图片
+        fail_dict = {}
+        for url,name in all_img_dict.items():
+            if not os.path.exists(os.path.join(self.out_folder_path, name)):
+                fail_dict.update({url:name})
+        print('downloading fail images...')
+        download_images(fail_dict,self.out_folder_path,self.user_agent)
 
 
 def recursion(cur_path):
@@ -183,8 +237,7 @@ def recursion(cur_path):
             recursion(p)
         elif filename.strip() == 'out':
             continue
-        else:
-            MdImageLocal(md_path=cur_path, log=args.log, modify_source=args.modify_source).run()
+    MdImageLocal(md_path=cur_path, log=args.log, modify_source=args.modify_source).run()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
1. 针对单个文件夹，仅新建一个 MdImageLocal 类；
2. 保存 markdown 原文件中的图片链接和文件路径之间的对应关系到 `all_img_dict.json`；
3. 针对单个文件夹，如果文件夹不是 `.assets` 文件夹，则判断 `all_img_dict.json` 文件是否存在，若不存在，则遍历读取 markdown 文件并创建该文件，若存在，则读取已存在的 `all_img_dict.json` 并保存到 `all_img_dict` 字典，防止重复下载；
4. 在一轮下载结束后，遍历 `all_img_dict` 字典中的文件路径，判断是否有图片下载失败，如果有，则将图片链接和文件路径加入 `fail_dict`，并按照 noasync 方式下载；
5. 下载图片时，检查图片文件是否已存在，如果存在则跳过，防止重复下载。